### PR TITLE
Qualify Input annotations for internal properties

### DIFF
--- a/test-lab-plugin/src/main/kotlin/com/simple/gradle/testlab/tasks/ShowCatalog.kt
+++ b/test-lab-plugin/src/main/kotlin/com/simple/gradle/testlab/tasks/ShowCatalog.kt
@@ -7,6 +7,7 @@ import com.simple.gradle.testlab.model.GoogleApiConfig
 import org.gradle.api.DefaultTask
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.HelpTasksPlugin
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.property
 import javax.inject.Inject
@@ -15,6 +16,7 @@ import javax.inject.Inject
 open class ShowCatalog @Inject constructor(
     objects: ObjectFactory
 ) : DefaultTask() {
+    @Input
     val googleApi = objects.property<GoogleApiConfig>()
 
     init {

--- a/test-lab-plugin/src/main/kotlin/com/simple/gradle/testlab/tasks/TestLabTest.kt
+++ b/test-lab-plugin/src/main/kotlin/com/simple/gradle/testlab/tasks/TestLabTest.kt
@@ -29,6 +29,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
@@ -42,9 +43,11 @@ open class TestLabTest @Inject constructor(
 ) : DefaultTask() {
     @Input @Optional val appPackageId: Property<String?> = objects.property()
     @Input val googleApiConfig: Property<GoogleApiConfig> = objects.property()
-    @Input internal val prefix: Property<String> = objects.property()
-    @Input internal val testConfig: Property<TestConfigInternal> = objects.property()
-    @InputFile internal val uploadResults: RegularFileProperty = objects.fileProperty()
+
+    @get:Input internal val prefix: Property<String> = objects.property()
+    @get:Input internal val testConfig: Property<TestConfigInternal> = objects.property()
+    @get:InputFile internal val uploadResults: RegularFileProperty = objects.fileProperty()
+
     @OutputDirectory val outputDir: DirectoryProperty = objects.directoryProperty().apply {
         set(layout.buildDirectory.dir("test-results/$name"))
     }
@@ -61,7 +64,6 @@ open class TestLabTest @Inject constructor(
             appPackageId.orNull
         )
         val historyId = historyPicker.getToolResultsHistoryId(historyName)
-        val storage = resultStorage(historyId)
 
         val testMatrix = TestMatrix()
             .setClientInfo(clientInfo())

--- a/test-lab-plugin/src/main/kotlin/com/simple/gradle/testlab/tasks/UploadFiles.kt
+++ b/test-lab-plugin/src/main/kotlin/com/simple/gradle/testlab/tasks/UploadFiles.kt
@@ -40,7 +40,7 @@ open class UploadFiles @Inject constructor(
     @InputFile val appApk: RegularFileProperty = objects.fileProperty()
     @InputFile @Optional val testApk: RegularFileProperty = objects.fileProperty()
     @InputFiles val additionalApks: ConfigurableFileCollection = objects.fileCollection()
-    @Input internal val deviceFiles: ListProperty<DeviceFile> = objects.listProperty()
+    @get:Input internal val deviceFiles: ListProperty<DeviceFile> = objects.listProperty()
     @Input val prefix: Property<String> = objects.property()
     @Input val google: Property<GoogleApiConfig> = objects.property()
     @OutputFile val results: RegularFileProperty = objects.fileProperty().apply {


### PR DESCRIPTION
Fixes the `validatePlugins` task.