### PR TITLE
Add clientDetails property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [unreleased]
+
+### Added
+
+- Added a `clientDetails` property to the `testLab` extension and both `instrumentation` and `robo` tests. This is a map 
+  of arbitrary keys and values passed along with each test, which can be retrieved via Firebase Cloud Functions after
+  the test has completed.
+
 ## [0.5.0] - 2020-11-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -187,6 +187,16 @@ testLab {
         projectId = "my-project-id-12345"
     }
 
+    // Extra values to send with all tests for use with Cloud Functions.
+    //
+    // For each test, these values will be merged with the test's `clientDetails`,
+    // with the test's values taking priority for identical keys. 
+    //
+    // These values can be accessed via `testMatrix.clientInfo.details` in a Cloud Functions script. See the
+    // Firebase documentation for more information: 
+    // https://firebase.google.com/docs/test-lab/extend-with-functions#access_client_details]
+    clientDetails.put("pull-request", "https://github.com/owner/repo/pulls/1234")
+
     // Configures the test configurations for this project.
     tests {
 
@@ -382,6 +392,16 @@ testLab {
         projectId = "my-project-id-12345"
     }
 
+    // Extra values to send with all tests for use with Cloud Functions.
+    //
+    // For each test, these values will be merged with the test's `clientDetails`,
+    // with the test's values taking priority for identical keys. 
+    //
+    // These values can be accessed via `testMatrix.clientInfo.details` in a Cloud Functions script. See the
+    // Firebase documentation for more information: 
+    // https://firebase.google.com/docs/test-lab/extend-with-functions#access_client_details]
+    clientDetails.put("pull-request", "https://github.com/owner/repo/pulls/1234")
+
     // Configures the test configurations for this project.
     tests {
 
@@ -566,6 +586,16 @@ additionalApks.from(
     "/path/to/another.apk"
 )
 
+// Extra values to send with this test for use with Cloud Functions.
+//
+// These values will be merged with `testLab.clientDetails`, with the values from this 
+// test overriding existing values with identical keys.
+//
+// These values can be accessed via `testMatrix.clientInfo.details` in a Cloud Functions 
+// script. See the Firebase documentation for more information: 
+// https://firebase.google.com/docs/test-lab/extend-with-functions#access_client_details
+clientDetails.put("test-name", name)
+
 // Disables performance metrics recording; may reduce test latency.
 disablePerformanceMetrics.set(true)
 
@@ -659,6 +689,16 @@ additionalApks.from(
     "/path/to/some.apk",
     "/path/to/another.apk"
 )
+
+// Extra values to send with this test for use with Cloud Functions.
+//
+// These values will be merged with `testLab.clientDetails`, with the values from this 
+// test overriding existing values with identical keys.
+//
+// These values can be accessed via `testMatrix.clientInfo.details` in a Cloud Functions 
+// script. See the Firebase documentation for more information: 
+// https://firebase.google.com/docs/test-lab/extend-with-functions#access_client_details
+clientDetails.put("test-name", name)
 
 // Disables performance metrics recording; may reduce test latency.
 disablePerformanceMetrics = true

--- a/sample-kotlin/build.gradle.kts
+++ b/sample-kotlin/build.gradle.kts
@@ -43,6 +43,8 @@ testLab {
         projectId = "my-project-id-12345"
     }
 
+    clientDetails.put("pull-request", "https://github.com/owner/repo/pulls/1234")
+
     tests {
         instrumentation("instrumented") {
             common()
@@ -119,6 +121,7 @@ fun TestConfig.common() {
         "/path/to/some.apk",
         "/path/to/another.apk"
     )
+    clientDetails.put("test-name", name)
     disablePerformanceMetrics.set(true)
     disableVideoRecording.set(true)
     dontAutograntPermissions.set(true)

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -42,6 +42,8 @@ testLab {
         projectId = "my-project-id-12345"
     }
 
+    clientDetails.put("pull-request", "https://github.com/owner/repo/pulls/1234")
+
     tests {
         instrumentation("instrumented") {
             environmentVariables["key"] = "value"
@@ -76,6 +78,7 @@ testLab {
                     "/path/to/some.apk",
                     "/path/to/another.apk"
             )
+            clientDetails.put("test-name", name)
             disablePerformanceMetrics = true
             disableVideoRecording = true
             dontAutograntPermissions = true
@@ -137,6 +140,7 @@ testLab {
                     "/path/to/some.apk",
                     "/path/to/another.apk"
             )
+            clientDetails.put("test-name", name)
             disablePerformanceMetrics = true
             disableVideoRecording = true
             dontAutograntPermissions = true

--- a/test-lab-plugin/src/main/kotlin/com/simple/gradle/testlab/TestLabPlugin.kt
+++ b/test-lab-plugin/src/main/kotlin/com/simple/gradle/testlab/TestLabPlugin.kt
@@ -182,6 +182,11 @@ private fun Project.addTestTask(
         appFileMetadata.from(uploadTasks.map { task -> task.map { it.results } })
 
         appPackageId.set(variant.applicationId)
+        clientDetails.set(
+            providers.provider {
+                extension.clientDetails.get() + testConfig.clientDetails.get()
+            }
+        )
         googleApiConfig.set(extension.googleApi)
         prefix.set(extension.prefix)
         this.testConfig.set(testConfig)

--- a/test-lab-plugin/src/main/kotlin/com/simple/gradle/testlab/internal/AbstractTestConfig.kt
+++ b/test-lab-plugin/src/main/kotlin/com/simple/gradle/testlab/internal/AbstractTestConfig.kt
@@ -17,6 +17,7 @@ import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.kotlin.dsl.listProperty
+import org.gradle.kotlin.dsl.mapProperty
 import org.gradle.kotlin.dsl.newInstance
 import org.gradle.kotlin.dsl.property
 import org.gradle.kotlin.dsl.setProperty
@@ -30,9 +31,10 @@ internal abstract class AbstractTestConfig(
     private val providers: ProviderFactory
 ) : TestConfigInternal {
     override val account = objects.newInstance<DefaultAccountHandler>()
-    override val artifacts = objects.setProperty<Artifact>().empty()
+    override val artifacts = objects.setProperty<Artifact>()
+    override val clientDetails = objects.mapProperty<String, String>()
     override val devices = objects.listProperty<Device>()
-    override val files = objects.listProperty<DeviceFile>().empty()
+    override val files = objects.listProperty<DeviceFile>()
 
     override val additionalApks = objects.fileCollection()
     override val appPackageId = objects.property<String>()

--- a/test-lab-plugin/src/main/kotlin/com/simple/gradle/testlab/internal/DefaultTestLabExtension.kt
+++ b/test-lab-plugin/src/main/kotlin/com/simple/gradle/testlab/internal/DefaultTestLabExtension.kt
@@ -7,6 +7,8 @@ import com.simple.gradle.testlab.model.TestConfig
 import com.simple.gradle.testlab.model.TestsHandler
 import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
+import org.gradle.kotlin.dsl.mapProperty
 import org.gradle.kotlin.dsl.newInstance
 import org.gradle.kotlin.dsl.polymorphicDomainObjectContainer
 import java.time.ZoneId
@@ -20,6 +22,8 @@ internal open class DefaultTestLabExtension @Inject constructor(
     private val objects: ObjectFactory
 ) : TestLabExtensionInternal {
     override val googleApi: DefaultGoogleApiConfig = DefaultGoogleApiConfig()
+
+    override val clientDetails: MapProperty<String, String> = objects.mapProperty()
 
     override val testConfigs = objects.polymorphicDomainObjectContainer(TestConfig::class).apply {
         registerFactory(InstrumentationTest::class.java) { name ->

--- a/test-lab-plugin/src/main/kotlin/com/simple/gradle/testlab/model/TestConfig.kt
+++ b/test-lab-plugin/src/main/kotlin/com/simple/gradle/testlab/model/TestConfig.kt
@@ -1,9 +1,12 @@
+@file:Suppress("UnstableApiUsage")
+
 package com.simple.gradle.testlab.model
 
 import org.gradle.api.Action
 import org.gradle.api.Named
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
@@ -30,6 +33,20 @@ interface TestConfig : Named {
      * application's manifest.
      */
     @get:[Input Optional] val appPackageId: Property<String>
+
+    /**
+     * Extra values to send with this test for use with Cloud Functions.
+     *
+     * These values will be merged with the extension's [clientDetails][TestLabExtension.clientDetails], with the values
+     * from this test overriding existing values with identical keys.
+     *
+     * These values can be accessed via `testMatrix.clientInfo.details` in a Cloud Functions script. See the
+     * [Firebase documentation][https://firebase.google.com/docs/test-lab/extend-with-functions#access_client_details]
+     * for more information.
+     *
+     *     clientDetails.put("pull-request", "https://github.com/owner/repo/pulls/1234")
+     */
+    @get:Input val clientDetails: MapProperty<String, String>
 
     /** Disables performance metrics recording; may reduce test latency. */
     @get:Input val disablePerformanceMetrics: Property<Boolean>

--- a/test-lab-plugin/src/main/kotlin/com/simple/gradle/testlab/model/TestLabExtension.kt
+++ b/test-lab-plugin/src/main/kotlin/com/simple/gradle/testlab/model/TestLabExtension.kt
@@ -2,6 +2,7 @@ package com.simple.gradle.testlab.model
 
 import org.gradle.api.Action
 import org.gradle.api.PolymorphicDomainObjectContainer
+import org.gradle.api.provider.MapProperty
 import org.gradle.kotlin.dsl.GradleDsl
 
 /**
@@ -10,6 +11,7 @@ import org.gradle.kotlin.dsl.GradleDsl
  * Tests require a valid [Google API configuration][googleApi] and a
  * [test configuration][TestConfig].
  */
+@Suppress("UnstableApiUsage")
 @GradleDsl
 interface TestLabExtension {
     companion object {
@@ -24,6 +26,20 @@ interface TestLabExtension {
      * The Google API configuration to use for this project.
      */
     val googleApi: GoogleApiConfig
+
+    /**
+     * Extra values to send with all tests for use with Cloud Functions.
+     *
+     * For each test, these values will be merged with the test's [clientDetails][TestConfig.clientDetails], with the
+     * test's values taking priority for identical keys.
+     *
+     * These values can be accessed via `testMatrix.clientInfo.details` in a Cloud Functions script. See the
+     * [Firebase documentation][https://firebase.google.com/docs/test-lab/extend-with-functions#access_client_details]
+     * for more information.
+     *
+     *     clientDetails.put("pull-request", "https://github.com/owner/repo/pulls/1234")
+     */
+    val clientDetails: MapProperty<String, String>
 
     /**
      * The container of test configurations for this project.


### PR DESCRIPTION
Fixes #12 

Added `clientDetails` to both `TestLabExtension` and `TestConfig`, so the user can specify values common to all tests along with values specific to each test config. 