### PR TITLE
Fix formatting test targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: ci
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -3,7 +3,7 @@ name: snapshot
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   snapshot:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Added a `clientDetails` property to the `testLab` extension and both `instrumentation` and `robo` tests. This is a map 
   of arbitrary keys and values passed along with each test, which can be retrieved via Firebase Cloud Functions after
   the test has completed.
+  
+### Fixed
+
+- Fixed improper formatting of test targets; e.g. "`classcom.foo.Bar`" instead of "`class com.foo.Bar`". 
 
 ## [0.5.0] - 2020-11-13
 

--- a/test-lab-plugin/src/main/kotlin/com/simple/gradle/testlab/internal/DefaultTestTargets.kt
+++ b/test-lab-plugin/src/main/kotlin/com/simple/gradle/testlab/internal/DefaultTestTargets.kt
@@ -1,5 +1,6 @@
 package com.simple.gradle.testlab.internal
 
+import com.google.common.annotations.VisibleForTesting
 import com.simple.gradle.testlab.model.TestSize
 import com.simple.gradle.testlab.model.TestTargets
 import org.gradle.api.model.ObjectFactory
@@ -45,19 +46,22 @@ internal open class DefaultTestTargets @Inject constructor(
             annotations.get().format("annotation")
     }
 
-    private fun Set<String>.format(prefix: String): List<String> {
-        val (excludes, includes) = filterNot(String::isBlank)
-            .takeUnless(List<String>::isEmpty)
-            ?.map(String::trim)
-            ?.partition { it.startsWith("!") }
-            ?: return emptyList()
-        return listOfNotNull(
-            excludes
+    companion object {
+        @VisibleForTesting
+        internal fun Set<String>.format(prefix: String): List<String> {
+            val (excludes, includes) = filterNot(String::isBlank)
                 .takeUnless(List<String>::isEmpty)
-                ?.joinToString(",", "not${prefix.capitalize()}") { it.removePrefix("!") },
-            includes
-                .takeUnless(List<String>::isEmpty)
-                ?.joinToString(",", prefix)
-        )
+                ?.map(String::trim)
+                ?.partition { it.startsWith("!") }
+                ?: return emptyList()
+            return listOfNotNull(
+                excludes
+                    .takeUnless(List<String>::isEmpty)
+                    ?.joinToString(",", "not${prefix.capitalize()} ") { it.removePrefix("!") },
+                includes
+                    .takeUnless(List<String>::isEmpty)
+                    ?.joinToString(",", "$prefix ")
+            )
+        }
     }
 }

--- a/test-lab-plugin/src/test/kotlin/com/simple/gradle/testlab/DefaultTestTargetsTest.kt
+++ b/test-lab-plugin/src/test/kotlin/com/simple/gradle/testlab/DefaultTestTargetsTest.kt
@@ -1,0 +1,24 @@
+package com.simple.gradle.testlab
+
+import com.simple.gradle.testlab.internal.DefaultTestTargets.Companion.format
+import org.junit.Test
+import strikt.api.expectThat
+import strikt.assertions.containsExactlyInAnyOrder
+
+class DefaultTestTargetsTest {
+
+    @Test
+    fun formatsClasses() {
+        val targets = setOf(
+            "com.foo.Bar",
+            "com.foo.Bar#Baz",
+            "!com.foo.Quux",
+            "!com.foo.Quux#Bat"
+        )
+
+        expectThat(targets.format("class")).containsExactlyInAnyOrder(
+            "class com.foo.Bar,com.foo.Bar#Baz",
+            "notClass com.foo.Quux,com.foo.Quux#Bat"
+        )
+    }
+}


### PR DESCRIPTION
The prefix was missing a space, so we ended up with `classcom.foo.Bar` instead of `class com.foo.Bar`.